### PR TITLE
chore: Added the Deploy to Netlify button to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hydrogen App
 
+<a href="https://app.netlify.com/start/deploy?repository=https://github.com/hydrogen-netlify-starter"><img src="https://www.netlify.com/img/deploy/button.svg" alt="Deploy to Netlify"></a>
+
 Hydrogen is a React framework and SDK that you can use to build fast and dynamic Shopify custom storefronts.
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)


### PR DESCRIPTION
## Description

Adds the Deploy to Netlify button to the Hydrogen starter site.



## Related Tickets & Documents

https://github.com/netlify/pod-ecosystem-frameworks/issues/78

## QA Instructions, Screenshots, Recordings

1. Navigate to the README file on GitHub for this branch and click on the Deploy to Netlify button.

![CleanShot 2022-04-19 at 08 29 47](https://user-images.githubusercontent.com/833231/164003848-4b8e06a4-4ec7-4e37-bd77-d8e81f7f8418.png)

3. The repository is still private so an error will occur during deployment. This is expected. Once the repository is public, the deployment URL will work.

![CleanShot 2022-04-19 at 08 27 00](https://user-images.githubusercontent.com/833231/164003397-9ccc5cb6-15a7-456b-aa3d-bc5f3a122b92.png)
