### PR TITLE
chore: enabled legacy peer dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Description

Enabled legacy peer dependencies for npm, so that the dependency update in https://github.com/netlify/hydrogen-platform/pull/51 will work with this repository.

Closes #36

![A capybara enjoying a neck scratch](https://media.giphy.com/media/AQpUsaKCRD9gA/giphy.gif)